### PR TITLE
Improve Performance of Label Rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - dev-labels-layer
+      - dev-labels-layer-performance
 
 jobs:
   build:

--- a/src/data/map/label-plan.ts
+++ b/src/data/map/label-plan.ts
@@ -46,7 +46,22 @@ export function decodeLabelAngle(angle: number, extent: number): number {
 
 export const GLYPH_STRIDE = 4;
 
-export const PLACEMENT_STRIDE = 8;
+export const PLACEMENT_STRIDE = 7;
+
+/**
+ * Number of discrete angles a rotated glyph is baked at in the tile sheet.
+ *
+ * 256 buckets sit 1.4 degrees apart, which displaces a glyph corner by well
+ * under a tenth of a pixel at the sizes these labels are drawn. Measurement on
+ * real z=15 tiles showed a coarser table is not worth the angular error: going
+ * all the way down to 32 buckets shrinks the sheet by only ~13%, because its
+ * size is dominated by the area of a rotated cell rather than by duplicated
+ * entries (53% of baked glyphs occur at a single angle, 24% at two).
+ */
+export const LABEL_ANGLE_BUCKETS = 256;
+
+/** Transparent margin around a baked rotated cell, in raster pixels. */
+const ROTATED_CELL_PADDING = 1;
 export const FEATURE_U32_STRIDE = 6;
 export const FEATURE_F32_STRIDE = 7;
 
@@ -403,6 +418,20 @@ export class LabelGlyphCache {
     if (sprite.page < 0) return;
     context.drawImage(this.pages[sprite.page].canvas, sprite.sx, sprite.sy, sprite.sw, sprite.sh, x, y, sprite.sw, sprite.sh);
   }
+
+  /**
+   * Draws `sprite` rotated by `angle`, centred in the `width` x `height` cell
+   * at (x, y). This is the one place a rotational transform is still paid, and
+   * it runs once per (sprite, angle) pair while the tile sheet is composed.
+   */
+  public blitRotated(sprite: GlyphSprite, context: OffscreenCanvasRenderingContext2D, x: number, y: number, angle: number, width: number, height: number): void {
+    if (sprite.page < 0) return;
+    context.save();
+    context.translate(x + width / 2, y + height / 2);
+    context.rotate(angle);
+    context.drawImage(this.pages[sprite.page].canvas, sprite.sx, sprite.sy, sprite.sw, sprite.sh, -sprite.sw / 2, -sprite.sh / 2, sprite.sw, sprite.sh);
+    context.restore();
+  }
 }
 
 export interface BuildLabelGlyphPlanOptions {
@@ -428,6 +457,12 @@ interface LocalPlacement {
   height: number;
   pixelWidth: number;
   pixelHeight: number;
+  /**
+   * Quantised angle this placement's sheet cell is baked at, or 0 (or absent)
+   * for an upright cell. Two placements share a cell only when they agree on
+   * both the sprite and this bucket.
+   */
+  bucket?: number;
 }
 
 interface LocalFeature {
@@ -648,7 +683,11 @@ function planAlongLine(cache: LabelGlyphCache, feature: LineStringLabelFeature, 
 
     const anchorX = coordinates[index][0];
     const anchorY = coordinates[index][1];
-    const angle = decodeLabelAngle(angles[index], extent);
+    // Snap to the sheet's angle table first, then derive the angle from the
+    // bucket, so the collision bounds below describe exactly the rotation that
+    // gets baked rather than one a fraction of a degree away from it.
+    const bucket = quantiseLabelAngle(angles[index], extent);
+    const angle = (bucket / LABEL_ANGLE_BUCKETS) * Math.PI * 2;
 
     sumX += anchorX;
     sumY += anchorY;
@@ -661,6 +700,7 @@ function planAlongLine(cache: LabelGlyphCache, feature: LineStringLabelFeature, 
       offsetX: -sprite.width / 2,
       offsetY: -sprite.height / 2,
       angle,
+      bucket,
       width: sprite.width,
       height: sprite.height,
       pixelWidth: sprite.sw,
@@ -979,22 +1019,100 @@ function resolveTileCollisions(locals: Array<LocalFeature>, extent: number): Arr
   return placed;
 }
 
+function quantiseLabelAngle(angle: number, extent: number): number {
+  if (!extent) return 0;
+  const bucket = Math.round((angle / extent) * LABEL_ANGLE_BUCKETS);
+  return ((bucket % LABEL_ANGLE_BUCKETS) + LABEL_ANGLE_BUCKETS) % LABEL_ANGLE_BUCKETS;
+}
+
+/**
+ * Rewrites every rotated placement into an equivalent axis-aligned one.
+ *
+ * The rotation moves into the tile sheet: `composeSheet` bakes one cell per
+ * (sprite, bucket) pair, so the renderer never hands the canvas a rotational
+ * transform. WebKit's 2D backend has no batching layer and leaves its blit fast
+ * path the moment the CTM rotates, so a rotated glyph costs far more per frame
+ * than an upright one; on a dense z=15 tile 91% of glyphs are along-line, which
+ * is why the cost dominates. Baking pays it once per tile in the worker instead
+ * of once per glyph per frame.
+ *
+ * The rewrite is exact, not an approximation. A placement draws its sprite at
+ * `offset` with size `width` x `height` inside a frame rotated about the anchor,
+ * so the sprite's centre lands at `R(angle) * (offset + size / 2)`. Putting an
+ * axis-aligned cell of the rotated bounding size on that same centre reproduces
+ * the original pixels, so nothing has to be counter-rotated at draw time.
+ *
+ * Run this AFTER collision resolution: it rewrites per-glyph geometry only, and
+ * the feature bounds the collision pass reserves already account for the
+ * rotated span (`planAlongLine` computes them from the same quantised angle).
+ */
+function bakeRotatedPlacements(features: Array<LocalFeature>): void {
+  for (const feature of features) {
+    for (const placement of feature.placements) {
+      const bucket = placement.bucket ?? 0;
+      if (bucket === 0 || !placement.sprite) continue;
+
+      const angle = (bucket / LABEL_ANGLE_BUCKETS) * Math.PI * 2;
+      const cos = Math.cos(angle);
+      const sin = Math.sin(angle);
+      const absCos = Math.abs(cos);
+      const absSin = Math.abs(sin);
+
+      // Design units per raster pixel. Both axes share it by construction, so
+      // carrying it through keeps the cell's design size exact.
+      const perPixel = placement.pixelWidth > 0 ? placement.width / placement.pixelWidth : 0;
+
+      // The rotated bounding box, plus one transparent pixel per side: the cell
+      // is resampled at draw time and an edge sample must not be able to reach
+      // into whichever cell the shelf packer puts next to it.
+      const cellWidth = placement.pixelWidth * absCos + placement.pixelHeight * absSin + ROTATED_CELL_PADDING * 2;
+      const cellHeight = placement.pixelWidth * absSin + placement.pixelHeight * absCos + ROTATED_CELL_PADDING * 2;
+
+      const centreX = placement.offsetX + placement.width / 2;
+      const centreY = placement.offsetY + placement.height / 2;
+      const rotatedCentreX = centreX * cos - centreY * sin;
+      const rotatedCentreY = centreX * sin + centreY * cos;
+
+      placement.width = cellWidth * perPixel;
+      placement.height = cellHeight * perPixel;
+      placement.offsetX = rotatedCentreX - placement.width / 2;
+      placement.offsetY = rotatedCentreY - placement.height / 2;
+      placement.pixelWidth = cellWidth;
+      placement.pixelHeight = cellHeight;
+      placement.angle = 0;
+    }
+  }
+}
+
 function composeSheet(cache: LabelGlyphCache, features: Array<LocalFeature>, maxSheetSize: number): { sheet: ImageBitmap; glyphs: Float32Array; indices: Map<LocalPlacement, number> } {
   const order: Array<LocalPlacement> = [];
-  const bySprite = new Map<unknown, number>();
+  // Sprite identity alone no longer identifies a cell: the same glyph baked at
+  // two different angles is two cells, while the same glyph at the same angle
+  // is still shared, which is what keeps the sheet from growing with the number
+  // of characters drawn along a road.
+  const bySprite = new Map<unknown, Map<number, number>>();
   const indices = new Map<LocalPlacement, number>();
 
   for (const feature of features) {
     for (const placement of feature.placements) {
       const identity = placement.sprite ?? placement.bitmap;
       if (!identity) continue;
-      const existing = bySprite.get(identity);
+      const bucket = placement.bucket ?? 0;
+
+      let byBucket = bySprite.get(identity);
+      if (!byBucket) {
+        byBucket = new Map<number, number>();
+        bySprite.set(identity, byBucket);
+      }
+
+      const existing = byBucket.get(bucket);
       if (existing !== undefined) {
         indices.set(placement, existing);
         continue;
       }
+
       const index = order.length;
-      bySprite.set(identity, index);
+      byBucket.set(bucket, index);
       indices.set(placement, index);
       order.push(placement);
     }
@@ -1040,7 +1158,14 @@ function composeSheet(cache: LabelGlyphCache, features: Array<LocalFeature>, max
     const placement = order[index];
     const offset = index * GLYPH_STRIDE;
     if (placement.sprite) {
-      cache.blit(placement.sprite, context, rects[offset], rects[offset + 1]);
+      const bucket = placement.bucket ?? 0;
+      if (bucket !== 0) {
+        // `bakeRotatedPlacements` already sized the cell to the rotated bounds,
+        // so the sprite is simply centred in it at the bucket's angle.
+        cache.blitRotated(placement.sprite, context, rects[offset], rects[offset + 1], (bucket / LABEL_ANGLE_BUCKETS) * Math.PI * 2, rects[offset + 2], rects[offset + 3]);
+      } else {
+        cache.blit(placement.sprite, context, rects[offset], rects[offset + 1]);
+      }
     } else if (placement.bitmap) {
       context.drawImage(placement.bitmap, rects[offset], rects[offset + 1]);
     }
@@ -1096,6 +1221,12 @@ export function buildLabelGlyphPlan(collection: LabelFeatureCollection, tile: Ma
   const placed = resolveTileCollisions(locals, extent);
   const survivors = placed.map((entry) => entry.local);
 
+  // Must run before the sheet is composed: it is what turns each rotated
+  // placement into an axis-aligned one and resizes its cell to the rotated
+  // bounds the shelf packer then allocates. Only survivors are baked, so
+  // collided labels cost nothing.
+  bakeRotatedPlacements(survivors);
+
   const { sheet, glyphs, indices } = composeSheet(cache, survivors, 2048);
 
   // One line per tile describing the whole super-sampling chain, so the atlas
@@ -1135,9 +1266,8 @@ export function buildLabelGlyphPlan(collection: LabelFeatureCollection, tile: Ma
       placements[offset + 2] = placement.anchorY;
       placements[offset + 3] = placement.offsetX;
       placements[offset + 4] = placement.offsetY;
-      placements[offset + 5] = placement.angle;
-      placements[offset + 6] = placement.width;
-      placements[offset + 7] = placement.height;
+      placements[offset + 5] = placement.width;
+      placements[offset + 6] = placement.height;
       placementIndex++;
     }
 

--- a/src/data/map/label-renderer.ts
+++ b/src/data/map/label-renderer.ts
@@ -263,5 +263,4 @@ export function drawLabelTiles(context: Context2D, tiles: Array<LabelTileView>, 
       }
     }
   }
-
 }

--- a/src/data/map/label-renderer.ts
+++ b/src/data/map/label-renderer.ts
@@ -117,7 +117,16 @@ function getPlanScales(plan: LabelGlyphPlan, index: number): [number, number] {
   return [scales[index * 2], scales[index * 2 + 1]];
 }
 
-function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: number, tileX: number, tileY: number, extentToPixel: number, designToPixel: number, scale: number, devicePixelRatio: number): void {
+/**
+ * Draws one feature's glyphs.
+ *
+ * Every cell in the tile sheet is already baked at its final angle, so this is
+ * an axis-aligned `drawImage` per glyph and the canvas transform is left
+ * untouched. That is deliberate: WebKit falls off its blit fast path under a
+ * rotational CTM, and along-line glyphs are the overwhelming majority of what a
+ * dense tile draws.
+ */
+function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: number, tileX: number, tileY: number, extentToPixel: number, designToPixel: number, scale: number): void {
   const featureOffset = featureIndex * FEATURE_U32_STRIDE;
   const flags = plan.features[featureOffset + 5];
 
@@ -128,7 +137,6 @@ function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: numb
   const dy = plan.bounds[featureIndex * FEATURE_F32_STRIDE + 6] * designToPixel;
   const unit = scale * designToPixel;
 
-  let rotated: boolean = false;
   for (let index = start; index < start + count; index++) {
     const offset = index * PLACEMENT_STRIDE;
     const glyphOffset = plan.placements[offset] * GLYPH_STRIDE;
@@ -143,21 +151,11 @@ function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: numb
     const anchorY = tileY + plan.placements[offset + 2] * extentToPixel + dy;
     const offsetX = plan.placements[offset + 3] * unit;
     const offsetY = plan.placements[offset + 4] * unit;
-    const angle = plan.placements[offset + 5];
-    const width = plan.placements[offset + 6] * unit;
-    const height = plan.placements[offset + 7] * unit;
-    if (angle) {
-      const cos = Math.cos(angle);
-      const sin = Math.sin(angle);
-      context.setTransform(cos * devicePixelRatio, sin * devicePixelRatio, -sin * devicePixelRatio, cos * devicePixelRatio, anchorX * devicePixelRatio, anchorY * devicePixelRatio);
-      context.drawImage(plan.sheet, sx, sy, sw, sh, offsetX, offsetY, width, height);
-      rotated = true;
-    } else {
-      context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
-      context.drawImage(plan.sheet, sx, sy, sw, sh, anchorX + offsetX, anchorY + offsetY, width, height);
-    }
+    const width = plan.placements[offset + 5] * unit;
+    const height = plan.placements[offset + 6] * unit;
+
+    context.drawImage(plan.sheet, sx, sy, sw, sh, anchorX + offsetX, anchorY + offsetY, width, height);
   }
-  if (rotated) context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
 }
 
 /**
@@ -241,7 +239,7 @@ export function drawLabelTiles(context: Context2D, tiles: Array<LabelTileView>, 
         const centreY = screenBBox.minY + plan.bounds[boundsOffset + 1] * extentToPixel;
         circles.get(styleReference)?.push([centreX, centreY]);
       } else {
-        drawGlyphs(context, plan, featureIndex, screenBBox.minX, screenBBox.minY, extentToPixel, designToPixel, scale, options.devicePixelRatio);
+        drawGlyphs(context, plan, featureIndex, screenBBox.minX, screenBBox.minY, extentToPixel, designToPixel, scale);
       }
     }
 

--- a/src/data/map/label-renderer.ts
+++ b/src/data/map/label-renderer.ts
@@ -20,6 +20,7 @@ export interface DrawLabelTilesOptions {
   width: number;
   height: number;
   dedupe?: boolean;
+  devicePixelRatio: number;
 }
 
 const SEAM_CELL_SIZE = 64;
@@ -116,7 +117,7 @@ function getPlanScales(plan: LabelGlyphPlan, index: number): [number, number] {
   return [scales[index * 2], scales[index * 2 + 1]];
 }
 
-function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: number, tileX: number, tileY: number, extentToPixel: number, designToPixel: number, scale: number): void {
+function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: number, tileX: number, tileY: number, extentToPixel: number, designToPixel: number, scale: number, devicePixelRatio: number): void {
   const featureOffset = featureIndex * FEATURE_U32_STRIDE;
   const flags = plan.features[featureOffset + 5];
 
@@ -127,6 +128,7 @@ function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: numb
   const dy = plan.bounds[featureIndex * FEATURE_F32_STRIDE + 6] * designToPixel;
   const unit = scale * designToPixel;
 
+  let rotated: boolean = false;
   for (let index = start; index < start + count; index++) {
     const offset = index * PLACEMENT_STRIDE;
     const glyphOffset = plan.placements[offset] * GLYPH_STRIDE;
@@ -144,18 +146,18 @@ function drawGlyphs(context: Context2D, plan: LabelGlyphPlan, featureIndex: numb
     const angle = plan.placements[offset + 5];
     const width = plan.placements[offset + 6] * unit;
     const height = plan.placements[offset + 7] * unit;
-
     if (angle) {
-      context.save();
-      context.translate(anchorX, anchorY);
-      context.rotate(angle);
+      const cos = Math.cos(angle);
+      const sin = Math.sin(angle);
+      context.setTransform(cos * devicePixelRatio, sin * devicePixelRatio, -sin * devicePixelRatio, cos * devicePixelRatio, anchorX * devicePixelRatio, anchorY * devicePixelRatio);
       context.drawImage(plan.sheet, sx, sy, sw, sh, offsetX, offsetY, width, height);
-      context.restore();
-      continue;
+      rotated = true;
+    } else {
+      context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+      context.drawImage(plan.sheet, sx, sy, sw, sh, anchorX + offsetX, anchorY + offsetY, width, height);
     }
-
-    context.drawImage(plan.sheet, sx, sy, sw, sh, anchorX + offsetX, anchorY + offsetY, width, height);
   }
+  if (rotated) context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
 }
 
 /**
@@ -239,7 +241,7 @@ export function drawLabelTiles(context: Context2D, tiles: Array<LabelTileView>, 
         const centreY = screenBBox.minY + plan.bounds[boundsOffset + 1] * extentToPixel;
         circles.get(styleReference)?.push([centreX, centreY]);
       } else {
-        drawGlyphs(context, plan, featureIndex, screenBBox.minX, screenBBox.minY, extentToPixel, designToPixel, scale);
+        drawGlyphs(context, plan, featureIndex, screenBBox.minX, screenBBox.minY, extentToPixel, designToPixel, scale, options.devicePixelRatio);
       }
     }
 

--- a/src/interface/map/field.css
+++ b/src/interface/map/field.css
@@ -8,6 +8,7 @@
   display: block;
   overflow: clip;
   visibility: hidden;
+  contain: paint;
 }
 
 .css_map_field[displayed="true"] {

--- a/src/interface/map/index.ts
+++ b/src/interface/map/index.ts
@@ -89,7 +89,6 @@ const requestedTileKeys = new Set<string>();
 /** Plans handed over by the label workers, cached here for the lifetime of the tile. */
 /** Reused every frame so the draw pass allocates nothing. */
 const labelTileViews: Array<LabelTileView> = [];
-let redrawLabels: boolean = true;
 
 interface ZoomLayer {
   /** Native zoom level this layer draws its tiles from */
@@ -128,7 +127,6 @@ const mapTileController = new MapTileController({
   },
   onMovement: function () {
     // Only repaint while moving. Requests are issued once movement settles.
-    redrawLabels = true;
     requestFrame();
   },
   onMovementEnd: function () {
@@ -136,7 +134,6 @@ const mapTileController = new MapTileController({
     requestFrame();
   },
   onResize: function () {
-    redrawLabels = true;
     resizeMapCanvas();
     synchronizeQueue();
     requestFrame();
@@ -157,9 +154,9 @@ export function openMap(lon: number = (120.886 + 122.004) / 2, lat: number = (24
   pushPageHistory('Map');
   showMap();
   resizeMapCanvas();
+  mapTileController.focusOn(lon, lat, zoom, duration);
   synchronizeQueue();
   requestFrame();
-  mapTileController.focusOn(lon, lat, zoom, duration);
   hidePreviousPage();
 }
 
@@ -207,7 +204,6 @@ function getTileKey(x: number, y: number, z: number): string {
 function handleTileResponse(response: MapLoaderResponse): void {
   // The loader has already cached the decoded tile. The render loop picks it up on the
   // next frame so it can fade in.
-  redrawLabels = true;
   requestFrame();
 }
 
@@ -541,10 +537,7 @@ function renderFrame(now: number): void {
     layerStack.splice(0, layerStack.length - 1);
   }
 
-  if (redrawLabels) {
-    redrawLabels = false;
-    drawLabels();
-  }
+  drawLabels();
 
   pruneFadeStates();
 

--- a/src/interface/map/index.ts
+++ b/src/interface/map/index.ts
@@ -575,6 +575,7 @@ function drawLabels(): void {
     // The fractional zoom, not the native one: point labels interpolate across it.
     zoom: mapTileController.zoom,
     width,
-    height
+    height,
+    devicePixelRatio
   });
 }

--- a/src/interface/map/map.css
+++ b/src/interface/map/map.css
@@ -12,6 +12,7 @@
   -webkit-user-drag: none;
   filter: var(--b-cssvar-map-filter);
   -webkit-filter: var(--b-cssvar-map-filter);
+  will-change: transform;
 }
 
 .css_map_field .css_map_labels {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,10 +87,10 @@ module.exports = (env, argv) => {
               matchOptions: {
                 ignoreSearch: false
               },
-              expiration: {
-                maxEntries: 16384,
-                maxAgeSeconds: 30 * 60 * 60 * 24
-              },
+              // expiration: {
+              //   maxEntries: 16384,
+              //   maxAgeSeconds: 30 * 60 * 60 * 24
+              // },
               cacheableResponse: {
                 statuses: [0, 200]
               }
@@ -104,10 +104,10 @@ module.exports = (env, argv) => {
               matchOptions: {
                 ignoreSearch: false
               },
-              expiration: {
-                maxEntries: 16384,
-                maxAgeSeconds: 30 * 60 * 60 * 24
-              },
+              // expiration: {
+              //   maxEntries: 16384,
+              //   maxAgeSeconds: 30 * 60 * 60 * 24
+              // },
               cacheableResponse: {
                 statuses: [0, 200]
               }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = (env, argv) => {
           },
           {
             urlPattern: /^https:\/\/erichsia7.github.io\/bus-map\/tiles\/[0-9]+\/[0-9]+\/[0-9]+\.webp/,
-            handler: 'StaleWhileRevalidate',
+            handler: 'CacheFirst',
             options: {
               cacheName: 'map-tiles',
               matchOptions: {
@@ -98,7 +98,7 @@ module.exports = (env, argv) => {
           },
           {
             urlPattern: /^https:\/\/erichsia7.github.io\/bus-map\/labels\/[0-9]+\/[0-9]+\/[0-9]+\.gz/,
-            handler: 'StaleWhileRevalidate',
+            handler: 'CacheFirst',
             options: {
               cacheName: 'map-labels',
               matchOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,10 +87,10 @@ module.exports = (env, argv) => {
               matchOptions: {
                 ignoreSearch: false
               },
-              // expiration: {
-              //   maxEntries: 16384,
-              //   maxAgeSeconds: 30 * 60 * 60 * 24
-              // },
+              expiration: {
+                // maxEntries: 16384,
+                purgeOnQuotaError: true
+              },
               cacheableResponse: {
                 statuses: [0, 200]
               }
@@ -104,10 +104,10 @@ module.exports = (env, argv) => {
               matchOptions: {
                 ignoreSearch: false
               },
-              // expiration: {
-              //   maxEntries: 16384,
-              //   maxAgeSeconds: 30 * 60 * 60 * 24
-              // },
+              expiration: {
+                // maxEntries: 16384,
+                purgeOnQuotaError: true
+              },
               cacheableResponse: {
                 statuses: [0, 200]
               }


### PR DESCRIPTION
1. Applying rotational transformation before drawImage makes WebKit struggling
2. Rotate glyphs once and cache them, ensuring every redraw on the main thread is axis-aligned